### PR TITLE
fix CARAPACE_SPECS_DIR

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,21 @@
 import os from 'node:os'
+import path from 'node:path'
 
-export const CARAPACE_SPECS_DIR = `${os.homedir()}/Library/Application Support/carapace/specs`
+function getCarapaceSpecsDir(): string {
+  const homeDir = os.homedir()
+  
+  switch (os.platform()) {
+    case 'darwin':
+      return path.join(homeDir, 'Library/Application Support/carapace/specs')
+    case 'win32':
+      // Windows uses AppData/Local or the XDG_CONFIG_HOME equivalent
+      const localAppData = (globalThis as any).process?.env?.LOCALAPPDATA || path.join(homeDir, 'AppData/Local')
+      return path.join(localAppData, 'carapace/specs')
+    default:
+      // Linux and other Unix-like systems use XDG Base Directory specification
+      const configHome = (globalThis as any).process?.env?.XDG_CONFIG_HOME || path.join(homeDir, '.config')
+      return path.join(configHome, 'carapace/specs')
+  }
+}
+
+export const CARAPACE_SPECS_DIR = getCarapaceSpecsDir()


### PR DESCRIPTION
In function of the OS, the carapace spec directory path is not the same.

Here is a modification to adapt the path in function of the OS.